### PR TITLE
Fixed horizontal scrollbars showing in win chrome and edge due to Map overflow.

### DIFF
--- a/server/website/css/app.css
+++ b/server/website/css/app.css
@@ -172,6 +172,7 @@ tbody > tr:nth-child(even) {
 
 #container {
     min-height: 200px;
+    overflow: hidden;
 }
 
 .tooltip-inner {

--- a/server/website/index.html
+++ b/server/website/index.html
@@ -9,7 +9,6 @@
         <link rel="stylesheet" href="./css/fontawesome.min.css">
         <link rel="stylesheet" href="./css/material-default.min.css">
         <link rel="stylesheet" href="./css/app.css">
-        <link rel="stylesheet" href="./css/gunmetal.css">
     </head>
     <body>
         <div class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark">


### PR DESCRIPTION
- Removed unused reference to gunmetal.css
- Added overflow:hidden to #container to prevent horizontal scroll on win chrome and edge.